### PR TITLE
fix day name index in example

### DIFF
--- a/examples/pcf8563_simpletest.py
+++ b/examples/pcf8563_simpletest.py
@@ -21,7 +21,7 @@ i2c_bus = busio.I2C(board.SCL, board.SDA)
 rtc = adafruit_pcf8563.PCF8563(i2c_bus)
 
 # Lookup table for names of days (nicer printing).
-days = ("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday")
+days = ("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
 
 
 # pylint: disable-msg=using-constant-test


### PR DESCRIPTION
Fix the day name indexes for the issue noted here: https://github.com/adafruit/Adafruit_CircuitPython_DS1307/issues/26